### PR TITLE
Fixing an issue where QuestInstance's RemoveUserEntry wasn't actually removing user entries

### DIFF
--- a/src/main/java/betterquesting/quests/QuestInstance.java
+++ b/src/main/java/betterquesting/quests/QuestInstance.java
@@ -659,10 +659,14 @@ public class QuestInstance
 		{
 			UserEntry entry = completeUsers.get(i);
 			
-			if(entry.uuid.equals(uuid))
-			{
-				completeUsers.remove(i);
-				UpdateClients();
+			// Iterate through our varargs...
+			for(int k = 0; k < uuid.length; k++) {
+				if(entry.uuid.equals(uuid[k]))
+				{
+					completeUsers.remove(i);
+					UpdateClients();
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
While doing some work integrating my mod with Better Questing, I noticed that QuestInstance's RemoveUserEntry method wasn't actually doing anything.  After I spent some time looking at it, I realized it was due to the fact that it's a vararg method - accepting an array of UUIDs instead of just one.  The method then goes on to check if the single UUID equals the entire list, which fails every time.

This could also be fixed by having the method no longer be a vararg method, but I didn't want to change the method signature, in the event that you, or other integrations, were passing multiple UUIDs to it at once.

Thanks.
