### PR TITLE
Save databases on the IO thread, not the main thread

### DIFF
--- a/src/main/java/betterquesting/handlers/AsyncSave.java
+++ b/src/main/java/betterquesting/handlers/AsyncSave.java
@@ -1,0 +1,47 @@
+package betterquesting.handlers;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.JsonObject;
+
+import betterquesting.api.utils.JsonHelper;
+import betterquesting.handlers.SaveLoadHandler.AsyncSave.AsyncSaveJob;
+import net.minecraft.world.storage.IThreadedFileIO;
+import net.minecraft.world.storage.ThreadedFileIOBase;
+
+class AsyncSave implements IThreadedFileIO {
+
+  private final List<AsyncSave.AsyncSaveJob> jobs = new ArrayList<>(); 
+
+  void enqueue(File file, JsonObject jObj) {
+    jobs.add(new AsyncSaveJob(file, jObj));
+  }
+  
+  void start() {
+    ThreadedFileIOBase.getThreadedIOInstance().queueIO(this);
+  }
+
+  @Override
+  public boolean writeNextIO() {
+    if (!jobs.isEmpty()) {
+      AsyncSave.AsyncSaveJob job = jobs.remove(0);
+      JsonHelper.WriteToFile(job.file, job.jObj);
+    }
+    return !jobs.isEmpty();
+  }
+  
+static class AsyncSaveJob  {
+
+  final File file; 
+  final JsonObject jObj;
+
+  AsyncSaveJob(File file, JsonObject jObj) {
+    this.file = file;
+    this.jObj = jObj;
+  }
+
+}
+
+}

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -22,14 +22,10 @@ import com.google.gson.JsonObject;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.storage.IThreadedFileIO;
-import net.minecraft.world.storage.ThreadedFileIOBase;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 public class SaveLoadHandler
 {
@@ -208,41 +204,6 @@ public class SaveLoadHandler
 	    BetterQuesting.logger.info("Loaded " + NameCache.INSTANCE.size() + " names");
 	    
 	    MinecraftForge.EVENT_BUS.post(new DatabaseEvent.Load());
-    }
-    
-    static class AsyncSave implements IThreadedFileIO {
-
-      private final List<AsyncSaveJob> jobs = new ArrayList<>(); 
-
-      void enqueue(File file, JsonObject jObj) {
-        jobs.add(new AsyncSaveJob(file, jObj));
-      }
-      
-      void start() {
-        ThreadedFileIOBase.getThreadedIOInstance().queueIO(this);
-      }
-
-      @Override
-      public boolean writeNextIO() {
-        if (!jobs.isEmpty()) {
-          AsyncSaveJob job = jobs.remove(0);
-          JsonHelper.WriteToFile(job.file, job.jObj);
-        }
-        return !jobs.isEmpty();
-      }
-
-    }
-
-    static class AsyncSaveJob  {
-
-      final File file; 
-      final JsonObject jObj;
-
-      AsyncSaveJob(File file, JsonObject jObj) {
-        this.file = file;
-        this.jObj = jObj;
-      }
-
     }
     
     public void saveDatabases()


### PR DESCRIPTION
Minecraft does all its chunk saving on an extra thread to not freeze the game. These changes do the same with the databases (those that go into the world/betterquesting folder).

I added this because writing them would freeze my server thread for 5-6 seconds(!) each time. (Modern Skyblock 3)

Your indenting and formatting is all over the place, so I didn't try to match any. Not laziness, I just don't know what to match ;)

BTW: If your NBT objects do not hold any references to live data but have a complete copy then you can change the AsyncSaveJob to hold the NBT instead of the JsonObjects to offload a little bit more processing time.